### PR TITLE
SDI-272 Allow release offenders to hospital if Active OUT

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/model/response/PrisonApiResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/model/response/PrisonApiResponses.kt
@@ -21,8 +21,11 @@ data class RestrictivePatient(
   val dischargeDetails: String? = null
 )
 
-data class OffenderBookingResponse(val bookingId: Long, val offenderNo: String, val inOutStatus: InOutStatus)
+data class OffenderBookingResponse(val bookingId: Long, val offenderNo: String, val activeFlag: ActiveFlag) {
+  val active: Boolean
+    get() = activeFlag == ActiveFlag.Y
+}
 
-enum class InOutStatus {
-  IN, OUT
+enum class ActiveFlag {
+  Y, N
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/services/RestrictedPatientsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/services/RestrictedPatientsService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.request.Cre
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.request.DischargeToHospitalRequest
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.request.MigrateInRequest
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.Agency
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.MovementResponse
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.RestrictedPatientDto
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.repositories.RestrictedPatientsRepository
@@ -40,8 +39,8 @@ class RestrictedPatientsService(
     checkNotExistingPatient(dischargeToHospital.offenderNo)
 
     prisonApiGateway.getOffenderBooking(dischargeToHospital.offenderNo)
-      ?.takeIf { it.inOutStatus == InOutStatus.IN }
-      ?: throw NoResultsReturnedException("No prisoner with status IN found for ${dischargeToHospital.offenderNo}")
+      ?.takeIf { it.active }
+      ?: throw NoResultsReturnedException("No prisoner with activeFlag 'Y' found for ${dischargeToHospital.offenderNo}")
 
     val dischargeToHospitalWithDefaultSupportingPrison = dischargeToHospital.copy(
       supportingPrisonId = dischargeToHospital.supportingPrisonId ?: dischargeToHospital.fromLocationId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/IntegrationTestBase.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.integration.wiremock.OAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.integration.wiremock.PrisonApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.integration.wiremock.PrisonerSearchApiMockServer
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.ActiveFlag
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 abstract class IntegrationTestBase {
@@ -87,7 +87,7 @@ abstract class IntegrationTestBase {
   ): WebTestClient.RequestHeadersSpec<*> {
     prisonApiMockServer.stubAgencyLocationForPrisons()
     prisonApiMockServer.stubAgencyLocationForHospitals()
-    prisonApiMockServer.stubOffenderBooking(prisonerNumber, InOutStatus.IN)
+    prisonApiMockServer.stubOffenderBooking(prisonerNumber, ActiveFlag.Y)
     prisonApiMockServer.stubDischargeToPrison(prisonerNumber)
 
     return webTestClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/RestrictedPatientServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/RestrictedPatientServiceIntegrationTest.kt
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.dataBuilders.makeDischargeRequest
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.dataBuilders.makeRestrictedPatient
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.gateways.PrisonApiGateway
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.ActiveFlag
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.OffenderBookingResponse
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.repositories.RestrictedPatientsRepository
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.services.RestrictedPatientsService
@@ -39,7 +39,7 @@ class RestrictedPatientServiceIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun beforeEach() {
-      whenever(prisonApiGateway.getOffenderBooking("F12345")).thenReturn(OffenderBookingResponse(1235467, "F12345", InOutStatus.IN))
+      whenever(prisonApiGateway.getOffenderBooking("F12345")).thenReturn(OffenderBookingResponse(1235467, "F12345", ActiveFlag.Y))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/SpringOauthIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/SpringOauthIntegrationTest.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.ActiveFlag
 
 @ActiveProfiles("test")
 class SpringOauthIntegrationTest : IntegrationTestBase() {
@@ -14,10 +14,10 @@ class SpringOauthIntegrationTest : IntegrationTestBase() {
     prisonApiMockServer.stubAgencyLocationForPrisons()
     prisonApiMockServer.stubAgencyLocationForHospitals()
     prisonApiMockServer.stubDischargeToPrison(OFFENDER_ONE)
-    prisonApiMockServer.stubOffenderBooking(OFFENDER_ONE, InOutStatus.IN)
+    prisonApiMockServer.stubOffenderBooking(OFFENDER_ONE, ActiveFlag.Y)
 
     prisonApiMockServer.stubDischargeToPrison(OFFENDER_TWO)
-    prisonApiMockServer.stubOffenderBooking(OFFENDER_TWO, InOutStatus.IN)
+    prisonApiMockServer.stubOffenderBooking(OFFENDER_TWO, ActiveFlag.Y)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/wiremock/PrisonApiMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.ActiveFlag
 
 class PrisonApiMockServer : WireMockServer(8989) {
   fun stubHealth() {
@@ -250,7 +250,7 @@ class PrisonApiMockServer : WireMockServer(8989) {
     )
   }
 
-  fun stubOffenderBooking(offenderNo: String, inOutStatus: InOutStatus) {
+  fun stubOffenderBooking(offenderNo: String, activeFlag: ActiveFlag) {
     stubFor(
       get(urlPathEqualTo("/api/bookings/offenderNo/$offenderNo"))
         .withQueryParams(
@@ -270,7 +270,7 @@ class PrisonApiMockServer : WireMockServer(8989) {
                   "offenderNo": "$offenderNo",
                   "bookingId": 1234567,
                   "ignoredField": "ignored",
-                  "inOutStatus": "${inOutStatus.name}"
+                  "activeFlag": "${activeFlag.name}"
                 }
               """.trimIndent()
             )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/service/RestrictedPatientServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/service/RestrictedPatientServiceTest.kt
@@ -26,8 +26,8 @@ import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.gateways.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.entities.RestrictedPatient
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.exceptions.NoResultsReturnedException
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.request.CreateExternalMovement
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.ActiveFlag
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.Agency
-import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.InOutStatus
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.model.response.OffenderBookingResponse
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.repositories.RestrictedPatientsRepository
 import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.services.DomainEventPublisher
@@ -232,7 +232,7 @@ class RestrictedPatientServiceTest {
       @Test
       fun `throws exception when offender is OUT`() {
         whenever(prisonApiGateway.getOffenderBooking(any())).thenReturn(
-          OffenderBookingResponse(1234567, "A1234AA", InOutStatus.OUT)
+          OffenderBookingResponse(1234567, "A1234AA", ActiveFlag.N)
         )
 
         Assertions.assertThrows(NoResultsReturnedException::class.java) {
@@ -253,7 +253,7 @@ class RestrictedPatientServiceTest {
       fun `removes recently persisted restricted patient on prison api discharge error`() {
         whenever(restrictedPatientsRepository.saveAndFlush(any())).thenReturn(makeRestrictedPatient())
         whenever(prisonApiGateway.getOffenderBooking(any())).thenReturn(
-          OffenderBookingResponse(1234567, "A1234AA", InOutStatus.IN)
+          OffenderBookingResponse(1234567, "A1234AA", ActiveFlag.Y)
         )
         whenever(prisonApiGateway.dischargeToHospital(any())).thenThrow(WebClientResponseException::class.java)
 
@@ -279,7 +279,7 @@ class RestrictedPatientServiceTest {
       @BeforeEach
       fun beforeEach() {
         whenever(prisonApiGateway.getOffenderBooking(any())).thenReturn(
-          OffenderBookingResponse(1234567, "A1234AA", InOutStatus.IN)
+          OffenderBookingResponse(1234567, "A1234AA", ActiveFlag.Y)
         )
         whenever(restrictedPatientsRepository.saveAndFlush(any())).thenReturn(makeRestrictedPatient())
       }


### PR DESCRIPTION
The previous fix for this ticket switched to checking prison-api instead of prisoner-search due to a timing issue. However we inadvertently stopped offenders who are Active OUT from being released to hospital using RP.