### PR TITLE
SDI-357 single migrations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/config/WebClientConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/config/WebClientConfig.kt
@@ -65,17 +65,6 @@ class WebClientConfig(
   @Bean
   @RequestScope
   @Profile("!app-scope")
-  fun communityApiClientCreds(
-    clientRegistrationRepository: ClientRegistrationRepository,
-    authorizedClientRepository: OAuth2AuthorizedClientRepository,
-  ): WebClient? = getClientCredsWebClient(
-    "$communityApiUrl/secure",
-    authorizedClientManagerRequestScope(clientRegistrationRepository, authorizedClientRepository)
-  )
-
-  @Bean
-  @RequestScope
-  @Profile("!app-scope")
   fun caseNotesApiClientCreds(
     clientRegistrationRepository: ClientRegistrationRepository,
     authorizedClientRepository: OAuth2AuthorizedClientRepository,
@@ -107,9 +96,7 @@ class WebClientConfig(
   )
 
   @Bean
-  @Qualifier("communityApiClientCreds")
-  @Profile("app-scope")
-  fun communityApiClientCredsAppScope(
+  fun communityApiClientCreds(
     clientRegistrationRepository: ClientRegistrationRepository?,
     oAuth2AuthorizedClientService: OAuth2AuthorizedClientService?
   ): WebClient? = getClientCredsWebClient(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/controllers/RestrictedPatientsBatchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/controllers/RestrictedPatientsBatchController.kt
@@ -25,13 +25,13 @@ class RestrictedPatientsBatchController(
     batchReleaseDateRemoval.removeNonLifePrisonersPastConditionalReleaseDate()
 
   @Hidden
-  @PostMapping(value = ["/process-unknown-patients"])
+  @PostMapping(value = ["/process-unknown-patient"])
   @PreAuthorize("hasRole('RESTRICTED_PATIENT_MIGRATION')")
   /**
    * Internal endpoint to migrate unknown patients into Nomis and add them to Restricted Patients
    */
-  fun processUnknownPatients(@RequestBody patients: List<String>): List<UnknownPatientResult> =
-    unknownPatientService.migrateInUnknownPatients(patients)
+  fun processUnknownPatient(@RequestBody patient: String): UnknownPatientResult =
+    unknownPatientService.migrateInUnknownPatient(patient)
 
   @Hidden
   @PostMapping(value = ["/dryrun-unknown-patients"])
@@ -40,5 +40,5 @@ class RestrictedPatientsBatchController(
    * DRY RUN version - this will validate input only but perform no actions
    */
   fun dryRunProcessUnknownPatients(@RequestBody patients: List<String>): List<UnknownPatientResult> =
-    unknownPatientService.migrateInUnknownPatients(patients, dryRun = true)
+    unknownPatientService.migrateInUnknownPatientsDryRun(patients)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/gateways/CaseNoteApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/gateways/CaseNoteApiGateway.kt
@@ -11,7 +11,7 @@ class CaseNoteApiGateway(@Qualifier("caseNotesApiClientCreds")private val caseNo
   fun createCaseNote(caseNoteRequest: CaseNoteRequest): Unit =
     with(caseNoteRequest) {
       caseNoteApiClientCreds
-        .put()
+        .post()
         .uri("/case-notes/$offenderNumber")
         .bodyValue(
           mapOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/services/UnknownPatientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/services/UnknownPatientService.kt
@@ -26,11 +26,11 @@ class UnknownPatientService(
   private val prisonerSearchApiGateway: PrisonerSearchApiGateway,
 ) {
 
-  fun migrateInUnknownPatients(patients: List<String>, dryRun: Boolean = false): List<UnknownPatientResult> =
+  fun migrateInUnknownPatientsDryRun(patients: List<String>): List<UnknownPatientResult> =
     patients.drop(1)
-      .map { rawPatient -> migrateInUnknownPatient(rawPatient, dryRun) }
+      .map { rawPatient -> migrateInUnknownPatient(rawPatient, dryRun = true) }
 
-  private fun migrateInUnknownPatient(rawPatient: String, dryRun: Boolean): UnknownPatientResult =
+  fun migrateInUnknownPatient(rawPatient: String, dryRun: Boolean = false): UnknownPatientResult =
     runCatching {
       parsePatient(rawPatient)
         .let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/IntegrationTestBase.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.integration
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.AfterAll
@@ -235,16 +234,16 @@ abstract class IntegrationTestBase {
   }
 
   fun processUnknownPatientsWebClient(
-    csvData: List<String> = listOf(),
+    csvData: String = "any",
     headers: (HttpHeaders) -> Unit = {},
   ): WebTestClient.RequestHeadersSpec<*> {
     return webTestClient
       .post()
-      .uri("/process-unknown-patients")
+      .uri("/process-unknown-patient")
       .contentType(APPLICATION_JSON)
       .accept(APPLICATION_JSON)
       .headers(headers)
-      .bodyValue(jacksonObjectMapper().writeValueAsString(csvData))
+      .bodyValue(csvData)
   }
 
   fun saveRestrictedPatient(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/ProcessUnknownPatientsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/ProcessUnknownPatientsIntTest.kt
@@ -7,12 +7,13 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyList
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.services.UnknownPatientResult
 
 @ActiveProfiles("test")
 class ProcessUnknownPatientsIntTest : IntegrationTestBase() {
@@ -35,7 +36,7 @@ class ProcessUnknownPatientsIntTest : IntegrationTestBase() {
 
     @Test
     fun `should reject request with wrong role`() {
-      whenever(unknownPatientsService.migrateInUnknownPatients(anyList(), anyBoolean())).thenReturn(listOf())
+      whenever(unknownPatientsService.migrateInUnknownPatient(anyString(), anyBoolean())).thenReturn(anyResult())
 
       processUnknownPatientsWebClient(headers = setHeaders(roles = listOf("ROLE_IS_WRONG")))
         .exchange()
@@ -44,19 +45,21 @@ class ProcessUnknownPatientsIntTest : IntegrationTestBase() {
 
     @Test
     fun `should process request with valid token`() {
-      whenever(unknownPatientsService.migrateInUnknownPatients(anyList(), anyBoolean())).thenReturn(listOf())
+      whenever(unknownPatientsService.migrateInUnknownPatient(anyString(), anyBoolean())).thenReturn(anyResult())
 
       processUnknownPatientsWebClient(headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
     }
+
+    private fun anyResult() = UnknownPatientResult(mhcsReference = "any", success = false)
   }
 
   @Nested
   inner class DryRun {
     @Test
     fun `should call service for a dry run`() {
-      whenever(unknownPatientsService.migrateInUnknownPatients(anyList(), anyBoolean())).thenReturn(listOf())
+      whenever(unknownPatientsService.migrateInUnknownPatientsDryRun(anyList())).thenReturn(listOf())
 
       webTestClient
         .post()
@@ -68,7 +71,7 @@ class ProcessUnknownPatientsIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      verify(unknownPatientsService).migrateInUnknownPatients(any(), eq(true))
+      verify(unknownPatientsService).migrateInUnknownPatientsDryRun(any())
     }
   }
 
@@ -92,108 +95,82 @@ class ProcessUnknownPatientsIntTest : IntegrationTestBase() {
 
     @Test
     fun `should process valid records`() {
-      val testData = listOf(testRecord("header"), testRecord("valid"))
-
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("valid"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo("A1234AA")
-        .jsonPath("$[0].success").isEqualTo("true")
-        .jsonPath("$[0].errorMessage").isEmpty
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo("A1234AA")
+        .jsonPath("$.success").isEqualTo("true")
+        .jsonPath("$.errorMessage").isEmpty
     }
 
     @Test
     fun `should process invalid records`() {
-      val testData = listOf(testRecord("header"), testRecord("invalid_dob"))
-
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("invalid_dob"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo(null)
-        .jsonPath("$[0].success").isEqualTo("false")
-        .jsonPath("$[0].errorMessage").isEqualTo("Date of birth 1965-02-33 invalid")
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo(null)
+        .jsonPath("$.success").isEqualTo("false")
+        .jsonPath("$.errorMessage").isEqualTo("Date of birth 1965-02-33 invalid")
     }
 
     @Test
     fun `should handle create prisoner errors`() {
       prisonApiMockServer.stubCreatePrisonerError()
-      val testData = listOf(testRecord("header"), testRecord("valid"))
 
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("valid"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo(null)
-        .jsonPath("$[0].success").isEqualTo("false")
-        .jsonPath("$[0].errorMessage").value<String> { assertThat(it).contains("Create prisoner failed due to:").contains("Some user message") }
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo(null)
+        .jsonPath("$.success").isEqualTo("false")
+        .jsonPath("$.errorMessage").value<String> { assertThat(it).contains("Create prisoner failed due to:").contains("Some user message") }
     }
 
     @Test
     fun `should handle discharge to hospital server errors`() {
       prisonApiMockServer.stubDischargeToPrisonError("A1234AA")
-      val testData = listOf(testRecord("header"), testRecord("valid"))
 
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("valid"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo("A1234AA")
-        .jsonPath("$[0].success").isEqualTo("false")
-        .jsonPath("$[0].errorMessage").value<String> { assertThat(it).contains("Discharge to hospital failed due to").contains("some error") }
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo("A1234AA")
+        .jsonPath("$.success").isEqualTo("false")
+        .jsonPath("$.errorMessage").value<String> { assertThat(it).contains("Discharge to hospital failed due to").contains("some error") }
     }
 
     @Test
     fun `should handle update NOMS number errors`() {
       communityApiMockServer.stubUpdateNomsNumberError("crn")
-      val testData = listOf(testRecord("header"), testRecord("valid"))
 
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("valid"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo("A1234AA")
-        .jsonPath("$[0].success").isEqualTo("false")
-        .jsonPath("$[0].errorMessage").value<String> { assertThat(it).contains("Update community NOMS number failed due to:").contains("some error") }
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo("A1234AA")
+        .jsonPath("$.success").isEqualTo("false")
+        .jsonPath("$.errorMessage").value<String> { assertThat(it).contains("Update community NOMS number failed due to:").contains("some error") }
     }
 
     @Test
     fun `should handle create case note errors`() {
       caseNotesApiMockServer.stubCreateCaseNotesError("A1234AA")
-      val testData = listOf(testRecord("header"), testRecord("valid"))
 
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
+      processUnknownPatientsWebClient(csvData = testRecord("valid"), headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo("A1234AA")
-        .jsonPath("$[0].success").isEqualTo("false")
-        .jsonPath("$[0].errorMessage").value<String> { assertThat(it).contains("Create case note failed due to:").contains("some error") }
-    }
-
-    @Test
-    fun `should process multiple records`() {
-      val testData = listOf(testRecord("header"), testRecord("valid"), testRecord("invalid_dob"))
-
-      processUnknownPatientsWebClient(csvData = testData, headers = setHeaders(roles = listOf("ROLE_RESTRICTED_PATIENT_MIGRATION")))
-        .exchange()
-        .expectStatus().isOk
-        .expectBody()
-        .jsonPath("$[0].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[0].offenderNumber").isEqualTo("A1234AA")
-        .jsonPath("$[0].success").isEqualTo("true")
-        .jsonPath("$[0].errorMessage").isEmpty
-        .jsonPath("$[1].mhcsReference").isEqualTo("3/6170")
-        .jsonPath("$[1].offenderNumber").isEqualTo(null)
-        .jsonPath("$[1].success").isEqualTo("false")
-        .jsonPath("$[1].errorMessage").isEqualTo("Date of birth 1965-02-33 invalid")
+        .jsonPath("$.mhcsReference").isEqualTo("3/6170")
+        .jsonPath("$.offenderNumber").isEqualTo("A1234AA")
+        .jsonPath("$.success").isEqualTo("false")
+        .jsonPath("$.errorMessage").value<String> { assertThat(it).contains("Create case note failed due to:").contains("some error") }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/wiremock/CaseNotesApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsrestrictedpatientsapi/integration/wiremock/CaseNotesApiMockServer.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.hmppsrestrictedpatientsapi.integration.wire
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.put
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 
 class CaseNotesApiMockServer : WireMockServer(8102) {
   fun stubCreateCaseNote(offenderNumber: String) {
     stubFor(
-      put(urlEqualTo("/case-notes/$offenderNumber"))
+      post(urlEqualTo("/case-notes/$offenderNumber"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -19,7 +19,7 @@ class CaseNotesApiMockServer : WireMockServer(8102) {
 
   fun stubCreateCaseNotesError(offenderNumber: String) {
     stubFor(
-      put(urlEqualTo("/case-notes/$offenderNumber"))
+      post(urlEqualTo("/case-notes/$offenderNumber"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
A test run got a 504 from one of the calls to prison-api which then timed out the entire run and didn't return any results 😢 

The new plan is to write a script that performs the dry run against the entire spreadsheet before migrating each patient individually and saving the results to files. Script to follow...